### PR TITLE
Fix 8 mount locations

### DIFF
--- a/docker-run-ci.bash
+++ b/docker-run-ci.bash
@@ -4,9 +4,9 @@
 
 dir=$(pwd)
 
-docker run -t -v ${dir}:/${dir} wavelab/ubuntu:${DOCKER_DISTRO} /bin/bash /${dir}/${1}
+docker run -t -v ${dir}:${dir} wavelab/ubuntu:${DOCKER_DISTRO} /bin/bash ${dir}/${1}
 
 if [ $? -ne 0 ]; then
-    echo "Docker Run Failed: /${dir}/${1} failed"
+    echo "Docker Run Failed: ${dir}/${1} failed"
     exit 1
 fi

--- a/docker-run-ci.bash
+++ b/docker-run-ci.bash
@@ -1,13 +1,12 @@
 #!/bin/bash
 
-# {1}: Repository Name
-# {2}: Repository-relative-path to the repository's own CI test script
+# {1}: Repository-relative-path to the repository's own CI test script
 
 dir=$(pwd)
 
-docker run -t -v ${dir}:/${1} wavelab/ubuntu:${DOCKER_DISTRO} /bin/bash /${1}/${2}
+docker run -t -v ${dir}:/${dir} wavelab/ubuntu:${DOCKER_DISTRO} /bin/bash /${dir}/${1}
 
 if [ $? -ne 0 ]; then
-    echo "Error: ${1} docker run of ${1}/${2} failed"
+    echo "Docker Run Failed: /${dir}/${1} failed"
     exit 1
 fi


### PR DESCRIPTION
Closes #8 

Automatically take the mount directory from the pwd used by the current session as the user repo's root location. This works for Travis-CI but might merit an update later to idiot-proof it against calls outside the repo's root.